### PR TITLE
Fix for issue #10 (robot_status aggregation)

### DIFF
--- a/IRC_v2/industrial_robot_client/src/v2/robot_status_relay_handler.cpp
+++ b/IRC_v2/industrial_robot_client/src/v2/robot_status_relay_handler.cpp
@@ -252,9 +252,6 @@ bool RobotStatusRelayHandler::aggregate(const std::map<int, StatusMsg>&in,
       if (this->joint_map_[map_idx].group_id != group_id)
         continue;
 
-      // keep the latest timestamp
-      out[ns].header.stamp = std::max(in_msg.header.stamp, out[ns].header.stamp);
-
       // aggregate with existing messages
       if (out.count(ns)==0)
         out[ns] = in_msg;
@@ -286,7 +283,11 @@ RobotStatusRelayHandler::StatusMsg RobotStatusRelayHandler::aggregate(const Stat
 {
   StatusMsg out;
 
+  // keep the latest timestamp
+  ros::Time maxTime  = std::max(msg1.header.stamp, msg2.header.stamp);
+
   out.header          = msg1.header;
+  out.header.stamp    = maxTime;
   out.mode            = allOrUnknown(msg1.mode, msg2.mode);
   out.e_stopped       = allOrUnknown(msg1.e_stopped, msg2.e_stopped);
   out.drives_powered  = allOrUnknown(msg1.drives_powered, msg2.drives_powered);


### PR DESCRIPTION
The robot_status_relay_handler always aggregates incoming DynGrpStatus messages with a default (all-zeros) RobotStatus message.

The 'element access' ([]) operator will insert a new element (using the default ctor) into the map if the key given to it does not exist.  This caused an all-zeros RobotStatus msg to always exist, even if no previous conversion of a DynGrpStatusGroup for a particular namespace had already been done.

The second overload of 'aggregate(..)' then compared that all-zeros msg with the actual converted msg, but as most fields would not have equal values, would set them to UNKNOWN.

Relocating the timestamp comparison avoids inserting the default element and makes both 'aggregate(..)'s work as expected again.