### PR TITLE
Replace `xacro.py` to `xacro --inorder`

### DIFF
--- a/industrial_robot_pkg_gen/templates/load_launch.empy
+++ b/industrial_robot_pkg_gen/templates/load_launch.empy
@@ -1,3 +1,3 @@
 <launch>
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find @(package))/urdf/@(model).xacro'" />
+  <param name="robot_description" command="$(find xacro)/xacro --inorder '$(find @(package))/urdf/@(model).xacro'" />
 </launch>


### PR DESCRIPTION
This PR fixes https://github.com/ros-industrial/industrial_training/issues/220 issue.

Environment:
- OS: Ubuntu 16.04
- ROS: Kinetic